### PR TITLE
Adding stricter file-type checking during upload process

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16375,6 +16375,11 @@
         }
       }
     },
+    "file-type-checker": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/file-type-checker/-/file-type-checker-1.0.9.tgz",
+      "integrity": "sha512-fF8UIya3QlakdS0O0TC0Au2LnttP0MDPYexlHv2wI7scaNP8DDhH/KgdhkA1pUMc43uTbC+6z2KLe16ntGNJ9A=="
+    },
     "file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "12.1.5",
     "@uppy/react": "^1.3.2",
+    "file-type-checker": "^1.0.9",
     "node-sass": "^4.12.0",
     "react": "^16.10.2",
     "react-app-rewired": "^2.1.3",

--- a/src/components/Experiment/QuickInput/Tabs/AudioInput/AudioRecorder.js
+++ b/src/components/Experiment/QuickInput/Tabs/AudioInput/AudioRecorder.js
@@ -112,15 +112,7 @@ export default function AudioRecorder(props) {
             source: 'Local'
         });
 
-        // console.log('uppyFile: ', uppyFile)
         setUppyFileId(uppyFile)
-
-        // Note: Can/do we actually want to automatically upload the file?
-        // const result = await uppy.upload(uppyFile);
-        // console.log(result);
-
-        // TODO: Check this on Staging, but useUploadInputControl should handle 
-        // setting props.setSelectedInput, which will then enable the "Run Model" button
     }
 
 

--- a/src/components/Experiment/QuickInput/Tabs/AudioInput/AudioRecorder.js
+++ b/src/components/Experiment/QuickInput/Tabs/AudioInput/AudioRecorder.js
@@ -1,12 +1,15 @@
 import React from "react";
 import { useState, useRef, useEffect } from "react";
 
+import { useUploadInputControl } from "../UploadInput/useUploadInputControl";
+import { getAllowedFileTypes } from "../../../../../helpers/UppyFileTypeCheckerPlugin";
+
+import { Dashboard } from "@uppy/react";
+
 import MicrophoneIcon from "../../../../../resources/icons/icon-microphone-white.png"
 import DownloadIcon from "../../../../../resources/icons/icon-download.png"
 
 import "./AudioRecorder.scss";
-import {getAllowedFileTypes, useUploadInputControl} from "../UploadInput/useUploadInputControl";
-import { Dashboard } from "@uppy/react";
 
 const mimeType = "audio/webm";
 

--- a/src/components/Experiment/QuickInput/Tabs/UploadInput/UploadInputsTab.js
+++ b/src/components/Experiment/QuickInput/Tabs/UploadInput/UploadInputsTab.js
@@ -5,7 +5,8 @@ import "@uppy/dashboard/dist/style.css";
 import "./UploadInputsTab.scss";
 import Task from "../../../../../helpers/Task";
 import useBEMNaming from "../../../../../common/useBEMNaming";
-import {getAllowedFileTypes, useUploadInputControl} from "./useUploadInputControl";
+import { useUploadInputControl } from "./useUploadInputControl";
+import { getAllowedFileTypes } from '../../../../../helpers/UppyFileTypeCheckerPlugin';
 
 export default function UploadInputsTab(props) {
   const {getBlock, getElement} = useBEMNaming("upload-inputs");

--- a/src/components/Experiment/QuickInput/Tabs/UploadInput/useUploadInputControl.js
+++ b/src/components/Experiment/QuickInput/Tabs/UploadInput/useUploadInputControl.js
@@ -3,35 +3,91 @@ import Uppy from '@uppy/core';
 import AwsS3Multipart from "@uppy/aws-s3-multipart";
 import {useEffect, useMemo, useState} from "react";
 
+import fileTypeChecker from "file-type-checker";
+
 import { audioToText, image_classification, image_enhancement, object_detection, semantic_segmentation } from '../../../../../helpers/TaskIDs';
+import UppyFileTypeCheckerPlugin from "../../../../../helpers/UppyFileTypeCheckerPlugin";
 
 export const getAllowedFileTypes = (task) => {
   switch (task) {
     case audioToText:
-      return ['audio/*', 'video/*'];
+      return {
+        fileTypes: ['aac', 'amr', 'flac', 'mp3', 'mp4', 'm4a', 'wav', 'webm'],
+        mimeTypes: ['audio/*', 'video/*'],
+      };
     case image_classification:
     case image_enhancement:
     case object_detection:
     case semantic_segmentation:
-      return ['image/*'];
+      return {
+        fileTypes: ['bmp', 'gif', 'ico', 'jpeg', 'pdf', 'png', 'psd'],
+        mimeTypes: ['image/*']
+      };
     default:
-      // Allow all file types
-      return ['*/*'];
+      // Allow all file types? Or disallow all file types?
+      return {
+        fileTypes: ['*'],
+        mimeTypes: '*/*'
+      };
   }
 }
 
+const checkFileType = (file, allowedFileTypes) => {
+  console.log('--non async check--')
+  console.log('FILE DATA: ', file);
+  const reader = new FileReader();
+  reader.onload = function(completionEvent) {
+    // console.log(completionEvent)
+
+    const result = completionEvent.currentTarget.result;
+    // console.log(result)
+
+    const fileCheckerResult = fileTypeChecker.detectFile(result)
+    // Note: Sometimes a renamed file seems to just return undefined?
+    if (fileCheckerResult === undefined) {
+      console.log('xxxxx undefined xxxxx')
+      // how do we throw an uppy error?
+      // return false;
+    }
+
+    console.log('fileCheckerResult', fileCheckerResult)
+    
+    const validation = fileTypeChecker.validateFileType(result, allowedFileTypes);
+    console.log('validation: ', validation)    
+    return validation;
+  }
+
+  reader.readAsArrayBuffer(file);
+
+}
+
+const confirmFileType = async (file, allowedFileTypes) => {
+  const blob = new Blob([file])
+  const bufferResult = await blob.arrayBuffer()
+  console.log(bufferResult)
+
+  const fileCheckerResult = fileTypeChecker.detectFile(bufferResult)
+  console.log(fileCheckerResult)
+
+  const validation = fileTypeChecker.validateFileType(bufferResult, allowedFileTypes);
+  console.log('validation: ', validation)  
+
+  return validation;
+
+}
+
 export const useUploadInputControl = (props) => {
+  // console.log('useUploadInputControl props', props)
   const [activeUser, setActiveUser] = useState("anonymous");
 
   const onBeforeUpload = (files) => {
-    Object.keys(files)
-      .forEach(key => {
+    Object.keys(files).forEach(key => {
         let file = files[key];
         files[key] = {
           ...file,
           name: `${activeUser}/${file.name}`,
         }
-      })
+      });
 
     return files;
   }
@@ -55,15 +111,64 @@ export const useUploadInputControl = (props) => {
     let u = Uppy({
       autoProceed: true,
       restrictions: {
-        allowedFileTypes: props.allowedFileTypes,
+        allowedFileTypes: props.allowedFileTypes.mimeTypes,
         maxNumberOfFiles: props.multiple ? 99 : 1,
       },
+      // onBeforeFileAdded: async (file) => {
+      //   // In the event that a user has deliberately changed a file extension to upload a "bad" file,
+      //   // we'll confirm the file type via file signature here
+      //   console.log('on before file added');
+      //   console.log(file)
+
+      //   // Check file validity
+      //   const isValidFile = checkFileType(file.data, props.allowedFileTypes.fileTypes);  // Non async version
+
+      //   // const isValidFile = await confirmFileType(file.data, props.allowedFileTypes.fileTypes);
+      //   console.log('isValidFile', isValidFile)
+
+      //   if (!isValidFile) {
+      //     // Show error message to user
+      //     u.info(`Something went wrong while adding "${file.data.name}".
+      //     Please check that the the file extension is correct, or try a different file.`, 'error', 10000);
+      //   }
+      
+      //   // Return t/f 
+      //   return isValidFile;
+      // },
       onBeforeUpload: onBeforeUpload
-    })
+    });
+
     u.use(AwsS3Multipart, {
       limit: 5,
       companionUrl: process.env.REACT_APP_COMPANION_URL
     });
+
+    u.use(UppyFileTypeCheckerPlugin, {allowedFileTypes: props.allowedFileTypes.fileTypes})
+
+    // u.on('file-added', async (file) => {
+    //   console.log(file);
+    //   const isValidFile = await confirmFileType(file.data, props.allowedFileTypes.fileTypes);
+    //   console.log(isValidFile)
+    //   if (!isValidFile) {
+    //     u.setFileState(file.id, 0)
+    //     // u.removeFile(file.id);
+    //     u.cancelAll();
+    //     u.setState({
+    //       files: {}
+    //     })
+    //     return false
+    //   } else {
+    //     return true;
+    //   }
+    // });
+
+    u.on('restriction-failed', (file, error) => {
+      // This is thrown if the user attempts to upload an unallowed file type
+      console.log('*** this file is not allowed ***')
+
+      // TODO: do some customized logic like showing system notice to users
+    });    
+
     u.on("complete", onComplete);
     
     return u;

--- a/src/components/Experiment/QuickInput/Tabs/UploadInput/useUploadInputControl.js
+++ b/src/components/Experiment/QuickInput/Tabs/UploadInput/useUploadInputControl.js
@@ -3,81 +3,9 @@ import Uppy from '@uppy/core';
 import AwsS3Multipart from "@uppy/aws-s3-multipart";
 import {useEffect, useMemo, useState} from "react";
 
-import fileTypeChecker from "file-type-checker";
-
-import { audioToText, image_classification, image_enhancement, object_detection, semantic_segmentation } from '../../../../../helpers/TaskIDs';
 import UppyFileTypeCheckerPlugin from "../../../../../helpers/UppyFileTypeCheckerPlugin";
 
-export const getAllowedFileTypes = (task) => {
-  switch (task) {
-    case audioToText:
-      return {
-        fileTypes: ['aac', 'amr', 'flac', 'mp3', 'mp4', 'm4a', 'wav', 'webm'],
-        mimeTypes: ['audio/*', 'video/*'],
-      };
-    case image_classification:
-    case image_enhancement:
-    case object_detection:
-    case semantic_segmentation:
-      return {
-        fileTypes: ['bmp', 'gif', 'ico', 'jpeg', 'pdf', 'png', 'psd'],
-        mimeTypes: ['image/*']
-      };
-    default:
-      // Allow all file types? Or disallow all file types?
-      return {
-        fileTypes: ['*'],
-        mimeTypes: '*/*'
-      };
-  }
-}
-
-const checkFileType = (file, allowedFileTypes) => {
-  console.log('--non async check--')
-  console.log('FILE DATA: ', file);
-  const reader = new FileReader();
-  reader.onload = function(completionEvent) {
-    // console.log(completionEvent)
-
-    const result = completionEvent.currentTarget.result;
-    // console.log(result)
-
-    const fileCheckerResult = fileTypeChecker.detectFile(result)
-    // Note: Sometimes a renamed file seems to just return undefined?
-    if (fileCheckerResult === undefined) {
-      console.log('xxxxx undefined xxxxx')
-      // how do we throw an uppy error?
-      // return false;
-    }
-
-    console.log('fileCheckerResult', fileCheckerResult)
-    
-    const validation = fileTypeChecker.validateFileType(result, allowedFileTypes);
-    console.log('validation: ', validation)    
-    return validation;
-  }
-
-  reader.readAsArrayBuffer(file);
-
-}
-
-const confirmFileType = async (file, allowedFileTypes) => {
-  const blob = new Blob([file])
-  const bufferResult = await blob.arrayBuffer()
-  console.log(bufferResult)
-
-  const fileCheckerResult = fileTypeChecker.detectFile(bufferResult)
-  console.log(fileCheckerResult)
-
-  const validation = fileTypeChecker.validateFileType(bufferResult, allowedFileTypes);
-  console.log('validation: ', validation)  
-
-  return validation;
-
-}
-
 export const useUploadInputControl = (props) => {
-  // console.log('useUploadInputControl props', props)
   const [activeUser, setActiveUser] = useState("anonymous");
 
   const onBeforeUpload = (files) => {
@@ -111,30 +39,11 @@ export const useUploadInputControl = (props) => {
     let u = Uppy({
       autoProceed: true,
       restrictions: {
+        // Uppy file-type restrictions will default the upload pop-up to the 
+        // allowed file types and reject any other types
         allowedFileTypes: props.allowedFileTypes.mimeTypes,
         maxNumberOfFiles: props.multiple ? 99 : 1,
       },
-      // onBeforeFileAdded: async (file) => {
-      //   // In the event that a user has deliberately changed a file extension to upload a "bad" file,
-      //   // we'll confirm the file type via file signature here
-      //   console.log('on before file added');
-      //   console.log(file)
-
-      //   // Check file validity
-      //   const isValidFile = checkFileType(file.data, props.allowedFileTypes.fileTypes);  // Non async version
-
-      //   // const isValidFile = await confirmFileType(file.data, props.allowedFileTypes.fileTypes);
-      //   console.log('isValidFile', isValidFile)
-
-      //   if (!isValidFile) {
-      //     // Show error message to user
-      //     u.info(`Something went wrong while adding "${file.data.name}".
-      //     Please check that the the file extension is correct, or try a different file.`, 'error', 10000);
-      //   }
-      
-      //   // Return t/f 
-      //   return isValidFile;
-      // },
       onBeforeUpload: onBeforeUpload
     });
 
@@ -143,31 +52,9 @@ export const useUploadInputControl = (props) => {
       companionUrl: process.env.REACT_APP_COMPANION_URL
     });
 
-    u.use(UppyFileTypeCheckerPlugin, {allowedFileTypes: props.allowedFileTypes.fileTypes})
-
-    // u.on('file-added', async (file) => {
-    //   console.log(file);
-    //   const isValidFile = await confirmFileType(file.data, props.allowedFileTypes.fileTypes);
-    //   console.log(isValidFile)
-    //   if (!isValidFile) {
-    //     u.setFileState(file.id, 0)
-    //     // u.removeFile(file.id);
-    //     u.cancelAll();
-    //     u.setState({
-    //       files: {}
-    //     })
-    //     return false
-    //   } else {
-    //     return true;
-    //   }
-    // });
-
-    u.on('restriction-failed', (file, error) => {
-      // This is thrown if the user attempts to upload an unallowed file type
-      console.log('*** this file is not allowed ***')
-
-      // TODO: do some customized logic like showing system notice to users
-    });    
+    // Adding extra type-checking to prevent against files with renamed 
+    // extentions from being maliciously uploaded
+    u.use(UppyFileTypeCheckerPlugin, {allowedFileTypes: props.allowedFileTypes.fileTypes});
 
     u.on("complete", onComplete);
     

--- a/src/helpers/UppyFileTypeCheckerPlugin.js
+++ b/src/helpers/UppyFileTypeCheckerPlugin.js
@@ -1,0 +1,72 @@
+// import BasePlugin from '@uppy/core/lib/BasePlugin.js';
+import Uppy from '@uppy/core';
+
+import fileTypeChecker from "file-type-checker";
+
+
+export default class UppyFileTypeCheckerPlugin extends Uppy.Plugin {
+	constructor(uppy, opts) {
+		super(uppy, opts);
+        console.log('opts', opts)
+		this.id = opts.id || 'UppyFileTypeCheckerPlugin';
+        // A type can be anything—some plugins use types to decide whether to do something to some other plugin.
+		// https://uppy.io/docs/guides/building-plugins/
+        this.type = 'upload-preprocessor';
+
+        this.allowedFileTypes = opts.allowedFileTypes;
+
+        this.prepareUpload = this.prepareUpload.bind(this); // ← this!
+
+        this.confirmFileType = this.confirmFileType.bind(this);
+	}
+
+    confirmFileType = async (fileIDs) => {
+        const file = this.uppy.getFile(fileIDs[0]);
+        // console.log('file', file)
+        const blob = new Blob([file.data])
+        // console.log('blob', blob)
+        const bufferResult = await blob.arrayBuffer()
+        // console.log(bufferResult)
+        const fileCheckerResult = fileTypeChecker.detectFile(bufferResult)
+        // console.log(fileCheckerResult)
+        console.log('allowed file types', this.allowedFileTypes)
+
+        const validation = fileTypeChecker.validateFileType(bufferResult, this.allowedFileTypes);
+        console.log('validation: ', validation)  
+
+        if (validation) {
+            return Promise.resolve()
+        } else {
+            this.uppy.cancelAll();
+            // Show error message to user
+            this.uppy.info(`Something went wrong while adding "${file.data.name}". ` + 
+            `Please check that the file extension is correct, or try a different file.`, 'error', 10000);  
+
+            return Promise.reject(new Error(`"${file.data.name}" failed validation by file-type-checker. ` + 
+            `Confirm the extension is correct and that it is in the list of allowed file types.`));
+        }
+
+
+
+        // return Promise.resolve();        
+    }    
+
+    async prepareUpload(fileIDs) {
+        console.log(fileIDs)
+		console.log(this); // `this` refers to the `MyPlugin` instance.
+
+
+		return Promise.resolve();
+	}
+	install() {
+		this.uppy.addPreProcessor(this.prepareUpload);
+
+        this.uppy.addPreProcessor(this.confirmFileType);
+	}
+
+	uninstall() {
+		this.uppy.removePreProcessor(this.prepareUpload);
+
+        this.uppy.removePreProcessor(this.confirmFileType);
+	}    
+}

--- a/src/helpers/UppyFileTypeCheckerPlugin.js
+++ b/src/helpers/UppyFileTypeCheckerPlugin.js
@@ -1,13 +1,37 @@
-// import BasePlugin from '@uppy/core/lib/BasePlugin.js';
 import Uppy from '@uppy/core';
+
+import { audioToText, image_classification, image_enhancement, object_detection, semantic_segmentation } from './TaskIDs';
 
 import fileTypeChecker from "file-type-checker";
 
+export const getAllowedFileTypes = (task) => {
+    switch (task) {
+      case audioToText:
+        return {
+          fileTypes: ['aac', 'amr', 'flac', 'mp3', 'mp4', 'm4a', 'wav', 'webm'],
+          mimeTypes: ['audio/*', 'video/*'],
+        };
+      case image_classification:
+      case image_enhancement:
+      case object_detection:
+      case semantic_segmentation:
+        return {
+          fileTypes: ['bmp', 'gif', 'ico', 'jpeg', 'pdf', 'png', 'psd'],
+          mimeTypes: ['image/*']
+        };
+      default:
+        // Allow all file types? Or disallow all file types?
+        return {
+          fileTypes: ['*'],
+          mimeTypes: '*/*'
+        };
+    }
+}
 
 export default class UppyFileTypeCheckerPlugin extends Uppy.Plugin {
 	constructor(uppy, opts) {
 		super(uppy, opts);
-        console.log('opts', opts)
+
 		this.id = opts.id || 'UppyFileTypeCheckerPlugin';
         // A type can be anything—some plugins use types to decide whether to do something to some other plugin.
 		// https://uppy.io/docs/guides/building-plugins/
@@ -15,24 +39,18 @@ export default class UppyFileTypeCheckerPlugin extends Uppy.Plugin {
 
         this.allowedFileTypes = opts.allowedFileTypes;
 
-        this.prepareUpload = this.prepareUpload.bind(this); // ← this!
-
         this.confirmFileType = this.confirmFileType.bind(this);
 	}
 
     confirmFileType = async (fileIDs) => {
+        // Note: This will break if we ever allow multiple uploads
         const file = this.uppy.getFile(fileIDs[0]);
-        // console.log('file', file)
-        const blob = new Blob([file.data])
-        // console.log('blob', blob)
-        const bufferResult = await blob.arrayBuffer()
-        // console.log(bufferResult)
-        const fileCheckerResult = fileTypeChecker.detectFile(bufferResult)
-        // console.log(fileCheckerResult)
-        console.log('allowed file types', this.allowedFileTypes)
+        const blob = new Blob([file.data]);
+        const bufferResult = await blob.arrayBuffer();
+        // Note: Doesn't seem like we need this additional check?
+        // const fileCheckerResult = fileTypeChecker.detectFile(bufferResult)
 
         const validation = fileTypeChecker.validateFileType(bufferResult, this.allowedFileTypes);
-        console.log('validation: ', validation)  
 
         if (validation) {
             return Promise.resolve()
@@ -41,32 +59,17 @@ export default class UppyFileTypeCheckerPlugin extends Uppy.Plugin {
             // Show error message to user
             this.uppy.info(`Something went wrong while adding "${file.data.name}". ` + 
             `Please check that the file extension is correct, or try a different file.`, 'error', 10000);  
-
+            // Print error in the console
             return Promise.reject(new Error(`"${file.data.name}" failed validation by file-type-checker. ` + 
             `Confirm the extension is correct and that it is in the list of allowed file types.`));
-        }
-
-
-
-        // return Promise.resolve();        
+        }      
     }    
 
-    async prepareUpload(fileIDs) {
-        console.log(fileIDs)
-		console.log(this); // `this` refers to the `MyPlugin` instance.
-
-
-		return Promise.resolve();
-	}
 	install() {
-		this.uppy.addPreProcessor(this.prepareUpload);
-
         this.uppy.addPreProcessor(this.confirmFileType);
 	}
 
 	uninstall() {
-		this.uppy.removePreProcessor(this.prepareUpload);
-
         this.uppy.removePreProcessor(this.confirmFileType);
 	}    
 }


### PR DESCRIPTION
Stricter file-type checking via `file-type-checker` npm library
[https://pixo.atlassian.net/browse/C3SR-515](https://pixo.atlassian.net/browse/C3SR-515)
- When a file is added via `uppy`, the restrictions there will default to showing the user only allowable file types
- If the user swaps to an "all files" view, they can select an unallowed file type, but uppy will reject the addition and the user will be shown an error message
- This PR adds an additional custom pre-processor to uppy and uses `file-type-checker` to confirm that the file type matches the file's signature, and is intended to reject files that have had their extensions renamed from an unallowable type to an allowable one (ie renaming a `.jpg` to a `.wav`)
- If a bad file is detected it is removed from the upload dashboard and an error message is shown to the user
- There is now a list of allowable file extensions/types, so those will need to be confirmed with the back-end to make sure we're not allowing/disallowing the incorrect files

Notes: 
- Confirm with Amir that we won't be uploading more than one file at a time